### PR TITLE
herokuのbugfix

### DIFF
--- a/db/migrate/20171104070729_add_profiles_to_profile.rb
+++ b/db/migrate/20171104070729_add_profiles_to_profile.rb
@@ -2,7 +2,7 @@ class AddProfilesToProfile < ActiveRecord::Migration[5.1]
   def change
     change_table :profiles do |t|
       t.integer  :sex ,    default: 1,null: false, limit: 1
-      t.date     :birthday,default: 1,null: false, index: true
+      t.date     :birthday,default: '1997-01-01',null: false, index: true
       t.string   :job,     index: true
       t.string   :hobby,   index: true
       t.string   :purpose, index: true

--- a/db/migrate/20171107142102_change_datatype_profiles_of_birthday.rb
+++ b/db/migrate/20171107142102_change_datatype_profiles_of_birthday.rb
@@ -1,9 +1,0 @@
-class ChangeDatatypeProfilesOfBirthday < ActiveRecord::Migration[5.1]
-  def up
-      change_column :profiles, :birthday, :date, null: false, default: '1997-01-1',index: true
-  end
-
-  def down
-      change_column :profiles, :birthday, :date, null: false, default: 1,index: true
-  end
-end

--- a/db/migrate/20171107142102_change_datatype_profiles_of_birthday.rb
+++ b/db/migrate/20171107142102_change_datatype_profiles_of_birthday.rb
@@ -1,0 +1,9 @@
+class ChangeDatatypeProfilesOfBirthday < ActiveRecord::Migration[5.1]
+  def up
+      change_column :profiles, :birthday, :date, null: false, default: '1997-01-1',index: true
+  end
+
+  def down
+      change_column :profiles, :birthday, :date, null: false, default: 1,index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171104070729) do
+ActiveRecord::Schema.define(version: 20171107142102) do
 
   create_table "profiles", force: :cascade do |t|
     t.integer "user_id"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20171104070729) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sex", limit: 1, default: 1, null: false
-    t.date "birthday", null: false
+    t.date "birthday", default: "1997-01-01", null: false
     t.string "job"
     t.string "hobby"
     t.string "purpose"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20171104070729) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "notifytoken"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107142102) do
+ActiveRecord::Schema.define(version: 20171104070729) do
 
   create_table "profiles", force: :cascade do |t|
     t.integer "user_id"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 20171107142102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
-    t.string "notifytoken"
   end
 
 end


### PR DESCRIPTION
```
PG::DatatypeMismatch: ERROR:  column "birthday" is of type date but default expression is of type integer
HINT:  You will need to rewrite or cast the expression.
```

の部分が原因らしく, 
herokuのlogを見ていると `birthday`　のアクセッサがプロフィール画面を呼び出された時に存在していないのがエラーの原因だった。

確認すると `rails db:migrate` の段階で通っていなく
これは　birthdayのdefault値が1であるのでinteger(整数型)と誤解され,dateと見られてなかったからっぽい。
なので雑にmigrateファイルを書き換えている。

新しいものを作るのも考えたが,そもそも`20171104070729_add_profiles_to_profile.rb` の時点で転けるのでここを書き換えた

雑に作ったテスト用のherokuで動作確認をした
https://frozen-falls-99279.herokuapp.com/