### PR TITLE
入力フォームを一つに

### DIFF
--- a/app/views/static_pages/community.html.erb
+++ b/app/views/static_pages/community.html.erb
@@ -1,18 +1,12 @@
-<h1>コミュニティ名</h1>
-<p><input type="text" name="community"></p>
-<h1>日時</h1>
-<p><input type="text" name="date"></p>
-
-<%# トップページが出来ればそこに飛ばしてー%>
-<input type="button" value="コミュニティ作成" onclick="location.href='/'" />
 <%= form_tag(sending_path, method: "get") do %>
   <%= hidden_field_tag 'placeName', @placeName %>
   <% @usersId.each do |u| %>
     <%= hidden_field_tag 'usersId[]', u %>
   <% end %>
-  <%= label_tag :"コミュニティ名" %>
+  <h1><%= label_tag :"コミュニティ名" %></h1>
   <%= text_field_tag :'comunity' %> 
-  <%= label_tag :"日時" %>
+  <h1><%= label_tag :"日時" %></h1>
   <%= text_field_tag :"date" %>
+  <br><br>
   <%= submit_tag("コミュニティ作成") %>
 <% end %>


### PR DESCRIPTION
## スプリントバックログ

[コミュニティ作成時のフォーム「コミュニティ名」「日時」をそれぞれ一つにする](https://trello.com/c/Zm5I3hO5/373-%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E5%90%8D%E3%80%8D%E3%80%8C%E6%97%A5%E6%99%82%E3%80%8D%E3%82%92%E5%85%A5%E5%8A%9B%E3%81%99%E3%82%8B%E7%94%BB%E9%9D%A2%E3%81%AE%E3%80%8C%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E5%90%8D%E3%80%8D%E3%80%8C%E6%97%A5%E6%99%82%E3%80%8D%E3%82%92%E8%A8%98%E5%85%A5%E3%81%99%E3%82%8B%E5%A0%B4%E6%89%80%E3%82%92%E3%81%9D%E3%82%8C%E3%81%9E%E3%82%8C%E4%B8%80%E3%81%A4%E3%81%AB%E3%81%99%E3%82%8B)

## やったこと
- 入力フォームを一つにした
- 以前存在した入力フォームの削除
- 入力フォームの位置の修正（縦側に表示）

## 備考


