### PR TITLE
レシピページとプロフィールの指摘修正

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -29,5 +29,7 @@
     <%= f.label :purpose, "目的"%>
     <%= f.text_field :purpose%>
 
+    <br /><br />
+
     <%= f.submit "登録" %>
 <% end %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -32,6 +32,8 @@
         <%= f.label :purpose, "目的"%>
         <%= f.text_field :purpose%>
 
+        <br /><br />
+
         <%= f.submit "登録" %>
     <% end  %>
 <% end %>

--- a/app/views/static_pages/recipe.html.erb
+++ b/app/views/static_pages/recipe.html.erb
@@ -18,6 +18,8 @@
   <%# 雑にリンク貼るとかでも良いのでは? %>
 <div id="recipe">
       <h1>作る料理を選択しよう！</h1>
+   <%= form_tag("/static_pages/community", method: "get") do %>
+
       <div class="nabe1">
 
            <a href="https://cookpad.com/recipe/3902277"><h1>超簡単節約♪冷蔵庫の残り物でちゃんこ鍋♪</h1></a>
@@ -55,7 +57,9 @@
                   <li>材料をきる。鍋にだしシャンプー約800、お塩小さじ半分、醤油・みりん・お酒各大2をいれ火をつける。具材をいれて火が通れば完成</li>
                   <li>補足 しめはおうどんを入れたり、おじやにしたり(*^.^*)</li>
                </ol>
-            <p>これにする! <input type="radio" value="ちゃんこ鍋">   </p>
+               <div id="rece1_button">
+                  <p>これにする! <%= radio_button_tag 'recipe_name', "ちゃんこ鍋" %></p>
+               </div>
       </div>
 
 <hr>
@@ -97,11 +101,12 @@
                   <li>[1]に水800mlと「ヤマサ昆布つゆ白だし」100mlを入れ、型で抜いた人参をのせ、火にかける。</li>
                   <li>豚肉の色が変わり、白菜が柔らかくなったら小口切りの小（万能）ねぎと白いりごまを散らし、火がとおったら頂く。</li>
                </ol>
-            <p>これにする! <input type="radio" value="ミルフィーユ鍋">   </p>
+               <div id="rece2_button">
+                  <p>これにする! <%= radio_button_tag 'recipe_name', "ミルフィーユ鍋" %></p>
+               </div>
       </div>
 
-   <%= form_tag("/static_pages/community", method: "get") do %>
-      <%= hidden_field_tag 'placeName', @placeName %>
+      <%= hidden_field_tag 'placeName', @placeName %> <%# form _for %>
       <% @usersId.each do |u| %>
         <%= hidden_field_tag 'usersId[]', u %>
       <% end %>

--- a/app/views/static_pages/recipe.html.erb
+++ b/app/views/static_pages/recipe.html.erb
@@ -17,7 +17,9 @@
   <%# TODO:レシピDBから持ってきてレンダリング %>
   <%# 雑にリンク貼るとかでも良いのでは? %>
 <div id="recipe">
+      <h1>作る料理を選択しよう！</h1>
       <div class="nabe1">
+
            <a href="https://cookpad.com/recipe/3902277"><h1>超簡単節約♪冷蔵庫の残り物でちゃんこ鍋♪</h1></a>
            <%= image_tag 'cook_pad.jpg', :width => '400', :height => '300', :align => 'right' %>
            <%# 画像はaseets/imagesにいれればok %>

--- a/app/views/static_pages/recipe.html.erb
+++ b/app/views/static_pages/recipe.html.erb
@@ -19,7 +19,7 @@
 <div id="recipe">
       <h1>作る料理を選択しよう！</h1>
    <%= form_tag("/static_pages/community", method: "get") do %>
-      <h2><%= submit_tag "コミュニティ作成へ" , :class => "btn btn-lg btn-primary" %></h2>
+      <h2><%= submit_tag "確定!!" , :class => "btn btn-lg btn-primary" %></h2>
 
       <div class="nabe1">
 

--- a/app/views/static_pages/recipe.html.erb
+++ b/app/views/static_pages/recipe.html.erb
@@ -19,6 +19,7 @@
 <div id="recipe">
       <h1>作る料理を選択しよう！</h1>
    <%= form_tag("/static_pages/community", method: "get") do %>
+      <h2><%= submit_tag "コミュニティ作成へ" , :class => "btn btn-lg btn-primary" %></h2>
 
       <div class="nabe1">
 
@@ -110,6 +111,5 @@
       <% @usersId.each do |u| %>
         <%= hidden_field_tag 'usersId[]', u %>
       <% end %>
-      <%= submit_tag("コミュニティ作成へ") %>
     <% end %>
 </div>


### PR DESCRIPTION
## スプリントバックログ

[料理の選択画面で「食べたい料理を選ぼう！」を表記](https://trello.com/c/SYoG6Snc/369-%E6%96%99%E7%90%86%E3%81%AE%E9%81%B8%E6%8A%9E%E7%94%BB%E9%9D%A2%E3%81%A7%E3%80%8C%E9%A3%9F%E3%81%B9%E3%81%9F%E3%81%84%E6%96%99%E7%90%86%E3%82%92%E9%81%B8%E3%81%BC%E3%81%86%EF%BC%81%E3%80%8D%E3%82%92%E8%A1%A8%E8%A8%98)
[料理の選択画面で選択を取り消す機能を付け加える（あわよくば選択は一つだけにしたい](https://trello.com/c/fi34NDI3/370-%E6%96%99%E7%90%86%E3%81%AE%E9%81%B8%E6%8A%9E%E7%94%BB%E9%9D%A2%E3%81%A7%E9%81%B8%E6%8A%9E%E3%82%92%E5%8F%96%E3%82%8A%E6%B6%88%E3%81%99%E6%A9%9F%E8%83%BD%E3%82%92%E4%BB%98%E3%81%91%E5%8A%A0%E3%81%88%E3%82%8B%EF%BC%88%E3%81%82%E3%82%8F%E3%82%88%E3%81%8F%E3%81%B0%E9%81%B8%E6%8A%9E%E3%81%AF%E4%B8%80%E3%81%A4%E3%81%A0%E3%81%91%E3%81%AB%E3%81%97%E3%81%9F%E3%81%84%EF%BC%89)
[料理画面の「コミュニティ作成へ」のボタンをページの上の方に変更](https://trello.com/c/AwMUYD4y/371-%E6%96%99%E7%90%86%E7%94%BB%E9%9D%A2%E3%81%AE%E3%80%8C%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E4%BD%9C%E6%88%90%E3%81%B8%E3%80%8D%E3%81%AE%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AE%E4%B8%8A%E3%81%AE%E6%96%B9%E3%81%AB%E5%A4%89%E6%9B%B4)
[料理画面の「コミュニティ作成へ」を「確定！」にボタンの名前を変更](https://trello.com/c/sU4lHC3R/372-%E6%96%99%E7%90%86%E7%94%BB%E9%9D%A2%E3%81%AE%E3%80%8C%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E4%BD%9C%E6%88%90%E3%81%B8%E3%80%8D%E3%82%92%E3%80%8C%E7%A2%BA%E5%AE%9A%EF%BC%81%E3%80%8D%E3%81%AB%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%92%E5%A4%89%E6%9B%B4)

- ･プロフィール編集の画面で｢登録｣ボタンが目的の記入の真横にきて少しわかりにくいと思ったので、真下

## やったこと

- レシピページに説明文１行つけました
- `form_for`を上に持っていき，ラジオボタンをrailsの機能で作りました
  - このため　`recipe_name` でレシピページからクエリパラメータを送信するようになっています
- コミュニティ形成への導線ボタンの文言，位置修正とCSSを当てました
- プロフィール作成編集に空白を追加しました

## 備考

![2017-11-16 11 52 54](https://user-images.githubusercontent.com/13062611/32871609-5f00be0e-cac5-11e7-981e-02865a5e4292.jpg)
![2017-11-16 11 52 42](https://user-images.githubusercontent.com/13062611/32871610-6250583a-cac5-11e7-879e-a43526434621.jpg)
