### PR TITLE
雑にルートページに遷移

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,9 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    unless @user.profile.nil?
+      redirect_to root_path
+    end
   end
 
   def new

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,3 @@
-<%= @user.name %>,
-    <%= @user.email %>
-        <%= link_to "Edit profile!", new_profile_path, class: "btn btn-lg btn-primary" %>
+   <%# <%= @user.name %>
+   <%# <%= @user.email %>
+<%= link_to "プロフィールを登録してください!", new_profile_path, class: "btn btn-lg btn-primary" %>


### PR DESCRIPTION
## スプリントバックログ

[ログインした後の流れをeditを介さないように修正](https://trello.com/c/agc4MoWn/406-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%97%E3%81%9F%E5%BE%8C%E3%81%AE%E6%B5%81%E3%82%8C%E3%82%92edit%E3%82%92%E4%BB%8B%E3%81%95%E3%81%AA%E3%81%84%E3%82%88%E3%81%86%E3%81%AB%E4%BF%AE%E6%AD%A3)

## やったこと
- プロフィールあるならログインしてルートに移動
- メールアドレスとか名前とかログインして出さなくても良いと思ったので削除
- ボタンの名前の修正

## 備考

