### PR TITLE
ユーザが気持ちよく使える

### DIFF
--- a/app/views/static_pages/community.html.erb
+++ b/app/views/static_pages/community.html.erb
@@ -4,9 +4,11 @@
     <%= hidden_field_tag 'usersId[]', u %>
   <% end %>
   <h1><%= label_tag :"コミュニティ名" %></h1>
-  <%= text_field_tag :'comunity' %> 
+    <p><small>(例:犬好きさんの集まり~鍋祭~)</small></p>
+  <%= text_field_tag :'comunity' %>
   <h1><%= label_tag :"日時" %></h1>
   <%= text_field_tag :"date" %>
+    <p><small>(例:12月4日18時)</small></p>
   <br><br>
   <%= submit_tag("コミュニティ作成") %>
 <% end %>

--- a/app/views/static_pages/friends.html.erb
+++ b/app/views/static_pages/friends.html.erb
@@ -1,7 +1,8 @@
 <div class="friends">
          <% if !@users.empty? %>
            <p><%= @place_name %>に集合できる人たちです!</p>
-          <p>一緒に食べたい人を選んでください</p>
+             <p>一緒に食べたい人を選んでください</p>
+             <p><small>※自分自身も追加してください</small></p>
 
             <%= form_tag(recipe_path, method: "get") do %>
               <%= hidden_field_tag 'placeName', @place_name %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -25,7 +25,7 @@
        <br>
        <% end %>
 <% else %>
-    <%= link_to "Sign up now!", signup_path, class: "btn btn-lg btn-primary" %>
+    <%= link_to "新規登録", signup_path, class: "btn btn-lg btn-primary" %>
     <%= link_to image_tag('6_001.jpg'),asset_path('rececomi_6.pdf') %>
 <% end %>
 </div>

--- a/app/views/static_pages/recipe.html.erb
+++ b/app/views/static_pages/recipe.html.erb
@@ -19,7 +19,6 @@
 <div id="recipe">
       <h1>作る料理を選択しよう！</h1>
    <%= form_tag("/static_pages/community", method: "get") do %>
-      <h2><%= submit_tag "確定!!" , :class => "btn btn-lg btn-primary" %></h2>
 
       <div class="nabe1">
 
@@ -111,5 +110,8 @@
       <% @usersId.each do |u| %>
         <%= hidden_field_tag 'usersId[]', u %>
       <% end %>
+
+      <%# -- buton --- %>
+     <h2><%= submit_tag "確定!!" , :class => "btn btn-lg btn-primary" %></h2>
     <% end %>
 </div>


### PR DESCRIPTION
## プロダクトバックログ

[5.ユーザが気持ちよく使える: 2](https://trello.com/c/Qp68Imkk/420-5%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%8C%E6%B0%97%E6%8C%81%E3%81%A1%E3%82%88%E3%81%8F%E4%BD%BF%E3%81%88%E3%82%8B-2)

## スプリントバックログ

[5. レシピの確定ボタンを下にもってくる](https://trello.com/c/S0HQGHHx/431-5-%E3%83%AC%E3%82%B7%E3%83%94%E3%81%AE%E7%A2%BA%E5%AE%9A%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E4%B8%8B%E3%81%AB%E3%82%82%E3%81%A3%E3%81%A6%E3%81%8F%E3%82%8B)
[5. 日時の入力画面に日時の例を用意する](https://trello.com/c/9bd04I3b/432-5-%E6%97%A5%E6%99%82%E3%81%AE%E5%85%A5%E5%8A%9B%E7%94%BB%E9%9D%A2%E3%81%AB%E6%97%A5%E6%99%82%E3%81%AE%E4%BE%8B%E3%82%92%E7%94%A8%E6%84%8F%E3%81%99%E3%82%8B)
[5. コミュニティ名入力画面に名前の例を用意する](https://trello.com/c/xLYZ2Hde/433-5-%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E5%90%8D%E5%85%A5%E5%8A%9B%E7%94%BB%E9%9D%A2%E3%81%AB%E5%90%8D%E5%89%8D%E3%81%AE%E4%BE%8B%E3%82%92%E7%94%A8%E6%84%8F%E3%81%99%E3%82%8B)
[5. edit profileを日本語にする](https://trello.com/c/KiQ9h3B7/434-5-edit-profile%E3%82%92%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AB%E3%81%99%E3%82%8B)
[5. ユーザ選択の画面で, 自分も選択するように説明文を用意する](https://trello.com/c/iAoYkmW8/435-5-%E3%83%A6%E3%83%BC%E3%82%B6%E9%81%B8%E6%8A%9E%E3%81%AE%E7%94%BB%E9%9D%A2%E3%81%A7-%E8%87%AA%E5%88%86%E3%82%82%E9%81%B8%E6%8A%9E%E3%81%99%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E8%AA%AC%E6%98%8E%E6%96%87%E3%82%92%E7%94%A8%E6%84%8F%E3%81%99%E3%82%8B)

## やったこと

- 基本上のログの通り
- EditProfileが既に修正されていたので `Sing in` を `新規登録` にした
## 備考

