### PR TITLE
作成されたコミュニティをとりあえずカウント

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ bundler_args: "--without development --deployment"
 cache: bundler
 before_script:
 - bundle exec rails  db:create
-- bundle exec rails  db:migrate
+- bundle exec rails  db:create
+- bundle exec rails  db:seed
 script:
 - bundle exec rails test
 deploy:
@@ -19,6 +20,7 @@ deploy:
     repo: AnaTofuZ/enpit_er
   run:
   - rails db:migrate
+  - rails db:seed
 env:
   secure: CChAmUo+SaRJROVskHc3xDPbPFJafEimMIhaEuhfrxY70ZurjN+gOMINTY7g36T9Qbzmg4/FaNQVf1mWjxvrYlNIkgYrr6o63wYOI5E13yT1fSYb3UukRTRJO5oZU6n/xXiKqi4y4gHvi59w4RskRirPcSNnEHDCsCjQEI4g/7u8MCTAvEgH+mJ8mIlhEzhF0GixL0fzTWEsotddH/hI2A9SQKtBDr8o0BhbZNTB7PqS2OicPX+xVUS/ZIoRF3AVpjq49EJ0gF+lAkY3qTCH54KWAIbNzbp6u8pGRmxA9BzprCQZDEHHEdPYdHIQTgB2/Z7OaTyfyax14X6p3hRDl+cJrh9rr3YRfrrrwRPiHfADDTIXLJlltpWMKNXayxuC92ekcOHcrNTCcXIoAHYi8lbLmwlATBls3V3koO31dtVoFEHhXFxJ/5RZd/kIHpJ6Us/pX8pAhQSoQJIUP6iC6X/N03/Lu1f0irCtDihfx3Ir4KwqENE7czC9Y5MN5Yd1CkvsXkkAaOPxPmQL70kNJtqijZUJkUuto8I4oMQWKWIvobkNr1/sZ7NrzGec+Kr/QuRamkT2EaxsfetbGwPMIH5qIYbuDaYF2CdoBnvpa415Ru3LxqRi4BYHbjhb6f8tAHd/eN+pk7duhRzHtgBfA3Hb/BSV4DbBJ/ihypoNo0I=
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ bundler_args: "--without development --deployment"
 cache: bundler
 before_script:
 - bundle exec rails  db:create
-- bundle exec rails  db:create
+- bundle exec rails  db:migrate
 - bundle exec rails  db:seed
+
 script:
 - bundle exec rails test
 deploy:

--- a/app/controllers/line_notify_controller.rb
+++ b/app/controllers/line_notify_controller.rb
@@ -20,6 +20,8 @@ class LineNotifyController < ApplicationController
    redirect_to root_url
   end
   def sending
+
+    access_counter #アクセスカウンタ
     #パラメータよりメッセージの作成:param一覧[comunity,member,recipe,place,date]
     users = User.find((params[:usersId].map(&:to_i)))
     message = "レシコミからです!!"+"\nコミュニティ名:"+params[:comunity]+"\n集合場所:"+params[:placeName]+"\n集合日時:"+params[:date]
@@ -30,4 +32,13 @@ class LineNotifyController < ApplicationController
     end
     redirect_to root_url
   end
+
+  private
+
+  def access_counter
+     Community_counters.increment_counter(:counter,:first)
+     counters = Community_counters.find(:first)
+     @counter =  counters.counter
+  end
+
 end

--- a/app/controllers/line_notify_controller.rb
+++ b/app/controllers/line_notify_controller.rb
@@ -36,8 +36,8 @@ class LineNotifyController < ApplicationController
   private
 
   def access_counter
-     Community_counters.increment_counter(:counter,:first)
-     counters = Community_counters.find(:first)
+     CommunityCounter.increment_counter(:counter,1)
+     counters = CommunityCounter.find(1)
      @counter =  counters.counter
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,10 +3,14 @@ class StaticPagesController < ApplicationController
     if logged_in?
       @user = User.find(session[:user_id])
       @items = Item.where(user_id: @user)
+
+      @counter = access_counter_show
     end
+      @counter = access_counter_show
   end
 
   def help
+   access_counter_increment
   end
 
   def list
@@ -55,5 +59,15 @@ class StaticPagesController < ApplicationController
       end
   end
 
+  def access_counter_increment
+     CommunityCounter.increment_counter(:counter,1)
+     counters = CommunityCounter.find(1)
+     @counter =  counters.counter
+  end
+
+  def access_counter_show
+     counters = CommunityCounter.find(1)
+     @counter =  counters.counter
+  end
 
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,8 +3,6 @@ class StaticPagesController < ApplicationController
     if logged_in?
       @user = User.find(session[:user_id])
       @items = Item.where(user_id: @user)
-
-      @counter = access_counter_show
     end
       @counter = access_counter_show
   end

--- a/app/models/community_counter.rb
+++ b/app/models/community_counter.rb
@@ -1,0 +1,2 @@
+class CommunityCounter < ApplicationRecord
+end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -26,6 +26,7 @@
        <% end %>
 <% else %>
     <%= link_to "新規登録", signup_path, class: "btn btn-lg btn-primary" %>
+    <p> 既にこのアプリで<%= @counter %>件のコミュニティが作成されました!</p>
     <%= link_to image_tag('6_001.jpg'),asset_path('rececomi_6.pdf') %>
 <% end %>
 </div>

--- a/db/migrate/20171123081305_create_community_counters.rb
+++ b/db/migrate/20171123081305_create_community_counters.rb
@@ -1,0 +1,9 @@
+class CreateCommunityCounters < ActiveRecord::Migration[5.1]
+  def change
+    create_table :community_counters do |t|
+      t.integer :counter, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171112090242) do
+ActiveRecord::Schema.define(version: 20171123081305) do
+
+  create_table "community_counters", force: :cascade do |t|
+    t.integer "counter", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "items", force: :cascade do |t|
     t.integer "user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+CommunityCounter.create(counter: 1)

--- a/test/fixtures/community_counters.yml
+++ b/test/fixtures/community_counters.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  counter: 1
+
+two:
+  counter: 1

--- a/test/fixtures/community_counters.yml
+++ b/test/fixtures/community_counters.yml
@@ -1,7 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   counter: 1
 
-two:
-  counter: 1

--- a/test/models/community_counter_test.rb
+++ b/test/models/community_counter_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommunityCounterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## スプリントバックログ

[3. コミュニティ確定ボタンを押した数をホームに表示する](https://trello.com/c/4YCWl8kq/428-3-%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E7%A2%BA%E5%AE%9A%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E6%8A%BC%E3%81%97%E3%81%9F%E6%95%B0%E3%82%92%E3%83%9B%E3%83%BC%E3%83%A0%E3%81%AB%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)

## やったこと
- カウンタ用のテーブルを追加(基本1データだけ)
- なのでmodelも追加しています
- ログインしていない時にトップページに行くとそんな感じに見える
- 基本はLINE通知のコントローラーが叩かれたらインクリメントする
- テスト様で `/help` にアクセスするとインクリメントされる

## 備考

![2017-11-23 17 53 59](https://user-images.githubusercontent.com/13062611/33164697-54f3c2dc-d077-11e7-8737-6a5199ba2d0f.jpg)

-  初期値を入れる必要があるので `bundle exec rails db:seed` 的なことをしてください
- 具体的なユーザーの保存はまだしてない