### PR TITLE
日本語の表示が崩れるのを修正する．

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,7 @@
  *
  *= require_self
  */
-
+@charset 'UTF-8';
 @import "bootstrap-sprockets";
 @import "bootswatch/sketchy/variables"; 
 @import "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,4 @@
 @import "font-awesome";
 
 @import "custom.scss";
+@import "shared.scss"

--- a/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
+++ b/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
@@ -3,9 +3,10 @@
 
 
 // Variables ===================================================================
-@import url(https://fonts.googleapis.com/earlyaccess/roundedmplus1c.css);
-/* フォントを指定したいところで */
 
+//$web-font-path: "https://fonts.googleapis.com/css?family=Neucha|Cabin+Sketch" !default;
+//@import url($web-font-path);
+@import url(https://fonts.googleapis.com/earlyaccess/roundedmplus1c.css);
 
 // Navbar ======================================================================
 

--- a/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
+++ b/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
@@ -6,7 +6,6 @@
 
 //$web-font-path: "https://fonts.googleapis.com/css?family=Neucha|Cabin+Sketch" !default;
 //@import url($web-font-path);
-@import url(https://fonts.googleapis.com/earlyaccess/roundedmplus1c.css);
 
 // Navbar ======================================================================
 

--- a/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
+++ b/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
@@ -3,9 +3,9 @@
 
 
 // Variables ===================================================================
+@import url(https://fonts.googleapis.com/earlyaccess/roundedmplus1c.css);
+/* フォントを指定したいところで */
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Neucha|Cabin+Sketch" !default;
-@import url($web-font-path);
 
 // Navbar ======================================================================
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,9 +1,13 @@
+@import url(https://fonts.googleapis.com/earlyaccess/roundedmplus1c.css);
 
 /* universal */
 
 body {
-    padding-top: 120px;
-    font-family: 'Rounded Mplus 1c';
+  padding-top: 120px;
+  font-family: 'Rounded Mplus 1c';
+}
+h1{
+  font-family: 'Rounded Mplus 1c';
 }
 
 section {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -2,7 +2,8 @@
 /* universal */
 
 body {
-  padding-top: 120px;
+    padding-top: 120px;
+    font-family: 'Rounded Mplus 1c';
 }
 
 section {

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -10,15 +10,18 @@
 table.food_tableList{
   width:100%;
   height:200px;
-	border-collapse: collapse;
-	text-align: left;
-	line-height: 1.5;
+  border-collapse: collapse;
+  text-align: left;
+  line-height: 1.5;
 
   td {
-  	width: 350px;
-  	padding: 20px;
-  	border: 1px solid #ccc;
+    width: 350px;
+    padding: 20px;
+    border: 1px solid #ccc;
     border-width: 1px 0px;
   }
 
+}
+h2{
+    font-family: 'Rounded Mplus 1c';
 }

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,14 +1,14 @@
 <h1>Profiles編集</h1>
-<p>集合場所を設定してください</p>
-<%= form_for @user.profile, :url => {:controller => :profiles, :action => :update} do |f| %>
+    <h4>集合場所を設定してください</h4>
+    <%= form_for @user.profile, :url => {:controller => :profiles, :action => :update} do |f| %>
     <%= f.select(:place_id,options_for_select([['琉大工学部', 1], ['北口ローソン', 2],['キリ学',3]]) )%>
 
-    <p>性別を選択して下さい</p>
-    <label><%= f.radio_button :sex, "male" %>男性</label>
-    <label><%= f.radio_button :sex, "female" %>女性</label>
+    <h4>性別を選択して下さい</h4>
+    &nbsp;&nbsp;&nbsp;&nbsp;<label><%= f.radio_button :sex, "male" %>男性&nbsp;&nbsp;&nbsp;&nbsp;</label>
+    <label><%= f.radio_button :sex, "female" %>女性&nbsp;&nbsp;&nbsp;&nbsp;</label>
     <label><%= f.radio_button :sex, "notapplicable" %>その他</label>
 
-    <p>生年月日を入力して下さい</p>
+    <h4>生年月日を入力して下さい</h4>
     <%=f.label :birthday%>
     <%=f.date_select(
         :birthday,
@@ -17,15 +17,15 @@
         end_year: (Time.now.year - 15),
         default: Date.new(1989, 1, 1),
         date_separator: '/')%>
-    <p>職業を設定して下さい</p>
+    <h4>職業を設定して下さい</h4>
     <%= f.label :job, "職業"%>
     <%= f.text_field :job%>
 
-    <p>趣味を設定して下さい</p>
+    <h4>趣味を設定して下さい</h4>
     <%= f.label :hobby, "趣味"%>
     <%= f.text_field :hobby%>
 
-    <p>レシコミをご利用になる目的を設定して下さい．(例1:残り物を無くすため;例2:友達を増やしたい等)</p>
+    <h4>レシコミをご利用になる目的を設定して下さい．(例1:残り物を無くすため;例2:友達を増やしたい等)</h4>
     <%= f.label :purpose, "目的"%>
     <%= f.text_field :purpose%>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,6 @@
 <h1>Profiles編集</h1>
+
+<br />
     <h4>集合場所を設定してください</h4>
     <%= form_for @user.profile, :url => {:controller => :profiles, :action => :update} do |f| %>
     <%= f.select(:place_id,options_for_select([['琉大工学部', 1], ['北口ローソン', 2],['キリ学',3]]) )%>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,4 @@
 <h1>Profiles編集</h1>
-
-<br />
     <h4>集合場所を設定してください</h4>
     <%= form_for @user.profile, :url => {:controller => :profiles, :action => :update} do |f| %>
     <%= f.select(:place_id,options_for_select([['琉大工学部', 1], ['北口ローソン', 2],['キリ学',3]]) )%>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,16 +1,16 @@
 <% if logged_in? %>
     <h1>Profiles設定</h1>
-    <p>集合場所を設定してください</p>
-    <%= form_for @user.profile, :url => {:controller => :profiles, :action => :create} do |f| %>
+        <h4>集合場所を設定してください</h4>
+        <%= form_for @user.profile, :url => {:controller => :profiles, :action => :create} do |f| %>
         <%= f.select(:place_id,options_for_select([['琉大工学部', 1], ['北口ローソン', 2],['キリ学',3]]) )%>
 
-        <p>性別を選択して下さい</p>
-        <label><%= f.radio_button :sex, "male" %>男性</label>
-        <label><%= f.radio_button :sex, "female" %>女性</label>
+        <h4>性別を選択して下さい</h4>
+        &nbsp;&nbsp;&nbsp;&nbsp;<label><%= f.radio_button :sex, "male" %>男性&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <label><%= f.radio_button :sex, "female" %>女性&nbsp;&nbsp;&nbsp;&nbsp;</label>
         <label><%= f.radio_button :sex, "notapplicable" %>その他</label>
 
 
-        <p>生年月日を入力して下さい</p>
+        <h4>生年月日を入力して下さい</h4>
         <%=f.label :birthday%>
         <%=f.date_select(
             :birthday,
@@ -20,15 +20,15 @@
             default: Date.new(1989, 1, 1),
             date_separator: '/')%>
 
-        <p>職業を設定して下さい</p>
+        <h4>職業を設定して下さい</h4>
         <%= f.label :job, "職業"%>
         <%= f.text_field :job%>
 
-        <p>趣味を設定して下さい</p>
+        <h4>趣味を設定して下さい</h4>
         <%= f.label :hobby, "趣味"%>
         <%= f.text_field :hobby%>
 
-        <p>レシコミでやりたいこと！(例：残り物をなくしたい！,友達を増やしたい!...etc)</p>
+        <h4>レシコミでやりたいこと！(例：残り物をなくしたい！,友達を増やしたい!...etc)</h4>
         <%= f.label :purpose, "目的"%>
         <%= f.text_field :purpose%>
 


### PR DESCRIPTION
## スプリントバックログ

<blockquote class="trello-card"><a href="https://trello.com/c/wDz8m3fk/455-%E3%83%95%E3%82%A9%E3%83%B3%E3%83%88%E3%81%8C%E6%97%A5%E6%9C%AC%E8%AA%9E%E5%AF%BE%E5%BF%9C%E3%81%97%E3%81%A6%E3%81%84%E3%81%AA%E3%81%84%E3%81%93%E3%81%A8%E3%81%AB%E3%82%88%E3%82%8B%E8%A1%A8%E7%A4%BA%E3%81%AE%E5%B4%A9%E3%82%8C%E3%81%AE%E8%A7%A3%E6%B6%88%EF%BC%8E">フォントが日本語対応していないことによる表示の崩れの解消．</a></blockquote>

## やったこと
- [https://googlefonts.github.io/japanese/]からフォントを選択して，適応させる．
- 以前のテーマは日本語に対応していないため，削除する．

## 備考
- フォントをRounded Mplus 1cで基本的に統一した．https://googlefonts.github.io/japanese/



