### PR TITLE
プロフィールを表にした

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -21,7 +21,7 @@ class StaticPagesController < ApplicationController
          redirect_to root_path
       end
 
-      @users = Profile.where(place_id: place_id)
+      @profiles = Profile.where(place_id: place_id)
   end
 
   def recipe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+        def show_gender(sex)
+            if sex == "male" then
+                "男性"
+            elsif sex == "female" then
+                "女性"
+            else
+                "その他"
+            end
+        end
 end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -15,13 +15,4 @@ module ProfilesHelper
 				puts "Error"
 			end
 	end
-        def show_gender(sex)
-            if sex == "male" then
-                "男性"
-            elsif sex == "female" then
-                "女性"
-            else
-                "その他"
-            end 
-        end
 end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -18,4 +18,9 @@ module StaticPagesHelper
 	 def defined_profile?
 		 !current_user.profile.nil?
 	 end
+
+    def age(birthday)
+      date_format = "%Y%m%d"
+      (Date.today.strftime(date_format).to_i - birthday.strftime(date_format).to_i)/10000
+    end
 end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -23,4 +23,11 @@ module StaticPagesHelper
       date_format = "%Y%m%d"
       (Date.today.strftime(date_format).to_i - birthday.strftime(date_format).to_i)/10000
     end
+
+    def show_none_profile(prof)
+      if prof.empty?
+         return '----  '
+      end
+      prof
+    end
 end

--- a/app/views/static_pages/friends.html.erb
+++ b/app/views/static_pages/friends.html.erb
@@ -27,6 +27,10 @@
                                 <th scope="row"><%= check_box_tag 'user_id[]', p.user_id,checked = false, :id => p.user_id %></th>
                                 <td><%= label_tag 'p.user.name', p.user.name %> </td>
                                 <td><%= show_gender(p.sex) %></td>
+                                <td><%= age(p.birthday) %></td>
+                                <td><%= show_none_profile(p.job) %></td>
+                                <td><%= show_none_profile(p.hobby) %></td>
+                                <td><%= show_none_profile(p.purpose) %></td>
                           </tr>
                        <% end %>
                    </tbody>

--- a/app/views/static_pages/friends.html.erb
+++ b/app/views/static_pages/friends.html.erb
@@ -6,6 +6,9 @@
 
 
              <div class="table-responsive">
+
+                     <%= form_tag(recipe_path, method: "get") do %>
+                     <%= hidden_field_tag 'placeName', @place_name %>
                 <table class="table table-striped">
                    <thead>
                       <tr>
@@ -19,19 +22,19 @@
                       </tr>
                    </thead>
                    <tbody>
-
-                     <%= form_tag(recipe_path, method: "get") do %>
-                       <%= hidden_field_tag 'placeName', @place_name %>
                        <% @profiles.each do |p| %>
-                             <%= check_box_tag 'user_id[]', p.user_id,checked = false, :id => p.user_id %>
-                             <%= label_tag 'p.user.name', p.user.name %> <br />
+                           <tr />
+                                <th scope="row"><%= check_box_tag 'user_id[]', p.user_id,checked = false, :id => p.user_id %></th>
+                                <td><%= label_tag 'p.user.name', p.user.name %> </td>
+                                <td><%= show_gender(p.sex) %></td>
+                          </tr>
                        <% end %>
                    </tbody>
                  </table>
-              </div>
 
-            <%= submit_tag("確定!!") %>
-            <% end %>
+                 <%= submit_tag("確定!!") %>
+                 <% end %>
+              </div>
 
          <%  else %>
             <p> まだ<%= @place_name %>に集まれる人はいないようです…</p>

--- a/app/views/static_pages/friends.html.erb
+++ b/app/views/static_pages/friends.html.erb
@@ -1,15 +1,35 @@
 <div class="friends">
-         <% if !@users.empty? %>
+         <% if !@profiles.empty? %>
            <p><%= @place_name %>に集合できる人たちです!</p>
              <p>一緒に食べたい人を選んでください</p>
              <p><small>※自分自身も追加してください</small></p>
 
-            <%= form_tag(recipe_path, method: "get") do %>
-              <%= hidden_field_tag 'placeName', @place_name %>
-              <% @users.each do |u| %>
-                    <%= check_box_tag 'user_id[]', u.user_id,checked = false, :id => u.user_id %>
-                    <%= label_tag 'u.user.name', u.user.name %> <br />
-              <% end %>
+
+             <div class="table-responsive">
+                <table class="table table-striped">
+                   <thead>
+                      <tr>
+                         <th scope="col">#</th>
+                         <th scope="col">名前</th>
+                         <th scope="col">性別</th>
+                         <th scope="col">年齢</th>
+                         <th scope="col">職業</th>
+                         <th scope="col">趣味</th>
+                         <th scope="col">やりたいこと</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+
+                     <%= form_tag(recipe_path, method: "get") do %>
+                       <%= hidden_field_tag 'placeName', @place_name %>
+                       <% @profiles.each do |p| %>
+                             <%= check_box_tag 'user_id[]', p.user_id,checked = false, :id => p.user_id %>
+                             <%= label_tag 'p.user.name', p.user.name %> <br />
+                       <% end %>
+                   </tbody>
+                 </table>
+              </div>
+
             <%= submit_tag("確定!!") %>
             <% end %>
 


### PR DESCRIPTION
## スプリントバックログ

[4. 選択時に他ユーザのプロフィールを表示する](https://trello.com/c/SOfTx8O0/429-4-%E9%81%B8%E6%8A%9E%E6%99%82%E3%81%AB%E4%BB%96%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)

## やったこと
- 変数名の修正
- プロフィールを表示する為に表形式に組み直した
- 登録されていないところは `---` が表示される
- 性別のヘルパーを使いたいので大本の継承元に記述を変更した

![2017-11-26 16 44 12](https://user-images.githubusercontent.com/13062611/33238107-4ced66de-d2c9-11e7-8f02-6d6c562c0214.jpg)


## 備考

CSSあたり良く解ってないのでスクロールバーはまだしてないです

