### PR TITLE
userの性別等を取り出し

### DIFF
--- a/app/controllers/line_notify_controller.rb
+++ b/app/controllers/line_notify_controller.rb
@@ -23,14 +23,17 @@ class LineNotifyController < ApplicationController
 
     access_counter #アクセスカウンタ
     #パラメータよりメッセージの作成:param一覧[comunity,member,recipe,place,date]
-    users = User.find((params[:usersId].map(&:to_i)))
+    profiles = Profile.find((params[:usersId].map(&:to_i)))
     message = "レシコミからです!!"+"\nコミュニティ名:"+params[:comunity]+"\n集合場所:"+params[:placeName]+"\n集合日時:"+params[:date]
-    message += "メンバー\n"
-    message += users.map{|user| "user.name (user.sex)\n"}
+    message << "メンバー\n"
+
+    profiles.each do |p|
+        message << "#{p.user.name} (#{p.sex})\n"
+    end
               #+"\nレシピ"+ params[:recipe]
               #+"\nメンバー"+users.name
-    users.each do |m|
-      line_notify_send_message(m.notifytoken,message)
+    profiles.each do |p|
+      line_notify_send_message(p.user.notifytoken,message)
     end
     redirect_to root_url
   end

--- a/app/controllers/line_notify_controller.rb
+++ b/app/controllers/line_notify_controller.rb
@@ -25,6 +25,8 @@ class LineNotifyController < ApplicationController
     #パラメータよりメッセージの作成:param一覧[comunity,member,recipe,place,date]
     users = User.find((params[:usersId].map(&:to_i)))
     message = "レシコミからです!!"+"\nコミュニティ名:"+params[:comunity]+"\n集合場所:"+params[:placeName]+"\n集合日時:"+params[:date]
+    message += "メンバー\n"
+    message += users.map{|user| "user.name (user.sex)\n"}
               #+"\nレシピ"+ params[:recipe]
               #+"\nメンバー"+users.name
     users.each do |m|

--- a/app/controllers/line_notify_controller.rb
+++ b/app/controllers/line_notify_controller.rb
@@ -23,7 +23,7 @@ class LineNotifyController < ApplicationController
 
     access_counter #アクセスカウンタ
     #パラメータよりメッセージの作成:param一覧[comunity,member,recipe,place,date]
-    profiles = Profile.find((params[:usersId].map(&:to_i)))
+    profiles = Profile.where(user_id: (params[:usersId].map(&:to_i)))
     message = "レシコミからです!!"+"\nコミュニティ名:"+params[:comunity]+"\n集合場所:"+params[:placeName]+"\n集合日時:"+params[:date]
     message << "メンバー\n"
 


### PR DESCRIPTION
## スプリントバックログ

[5. ユーザ情報を通知まで持ってくる](https://trello.com/c/N3Gv4drx/476-5-%E3%83%A6%E3%83%BC%E3%82%B6%E6%83%85%E5%A0%B1%E3%82%92%E9%80%9A%E7%9F%A5%E3%81%BE%E3%81%A7%E6%8C%81%E3%81%A3%E3%81%A6%E3%81%8F%E3%82%8B)
[5. 通知に男女その他比率を載せる](https://trello.com/c/w1geWfbv/474-5-%E9%80%9A%E7%9F%A5%E3%81%AB%E7%94%B7%E5%A5%B3%E3%81%9D%E3%81%AE%E4%BB%96%E6%AF%94%E7%8E%87%E3%82%92%E8%BC%89%E3%81%9B%E3%82%8B)
[5. 通知にユーザ名を載せる](https://trello.com/c/RkaRQa9d/475-5-%E9%80%9A%E7%9F%A5%E3%81%AB%E3%83%A6%E3%83%BC%E3%82%B6%E5%90%8D%E3%82%92%E8%BC%89%E3%81%9B%E3%82%8B)

## やったこと
```
    message << "メンバー\n"

    profiles.each do |p|
        message << "#{p.user.name} (#{p.sex})\n"
    end
```
などとして `message`に直接ユーザーの性別と名前をいれた
男女比は見ればわかるのでは?と思ったので性別を入れることで代替えした

また探す時に複数検索のためwhereを使うように修正した

## 備考
テスト^q^
