### PR TITLE
checkboxのcssを外す．ラジオボタンのcssを外す．

### DIFF
--- a/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
+++ b/app/assets/stylesheets/bootswatch/sketchy/_bootswatch.scss
@@ -135,67 +135,67 @@ select.form-control {
   border-radius: $border-radius-lg !important;
 }
 
-[type="checkbox"] {
-  position: relative;
-  appearance: none;
-  cursor: pointer;
+// [type="checkbox"] {
+//   position: relative;
+//   appearance: none;
+//   cursor: pointer;
 
-  &:before {
-    content: "";
-    position: absolute;
-    left: 0.0em;
-    top: -0.9em;
-    display: inline-block;
-    width: 15px;
-    height: 16px;
-    border: 2px solid $gray-800;
-    border-radius: 2px 8px 2px 4px / 5px 3px 5px 3px;
-  }
+//   &:before {
+//     content: "";
+//     position: absolute;
+//     left: 0.0em;
+//     top: -0.9em;
+//     display: inline-block;
+//     width: 15px;
+//     height: 16px;
+//     border: 2px solid $gray-800;
+//     border-radius: 2px 8px 2px 4px / 5px 3px 5px 3px;
+//   }
 
-  &:checked:after {
-    content: "x";
-    position: absolute;
-    left: 0.36em;
-    top: -0.48em;
-    font-size: 1.5rem;
-    line-height: 0.5;
-    color: $gray-800;
-  }
+//   &:checked:after {
+//     content: "x";
+//     position: absolute;
+//     left: 0.36em;
+//     top: -0.48em;
+//     font-size: 1.5rem;
+//     line-height: 0.5;
+//     color: $gray-800;
+//   }
 
-  &:disabled {
-    &:before {
-      border: 2px solid $gray-500;
-    }
-  }
-}
+//   &:disabled {
+//     &:before {
+//       border: 2px solid $gray-500;
+//     }
+//   }
+// }
 
-[type="radio"] {
-  position: relative;
-  appearance: none;
-  cursor: pointer;
+// [type="radio"] {
+//   position: relative;
+//   appearance: none;
+//   cursor: pointer;
 
-  &:before {
-    content: "";
-    position: absolute;
-    left: -1.2em;
-    top: -0.9em;
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    border: 2px solid $gray-800;
-    border-radius: 50% 45% 40% 50% / 40% 50% 50% 45%;
-  }
+//   &:before {
+//     content: "";
+//     position: absolute;
+//     left: -1.2em;
+//     top: -0.9em;
+//     display: inline-block;
+//     width: 16px;
+//     height: 16px;
+//     border: 2px solid $gray-800;
+//     border-radius: 50% 45% 40% 50% / 40% 50% 50% 45%;
+//   }
 
-  &:checked:before {
-    background-color: $gray-800;
-  }
+//   &:checked:before {
+//     background-color: $gray-800;
+//   }
 
-  &:disabled {
-    &:before {
-      border: 2px solid $gray-500;
-    }
-  }
-}
+//   &:disabled {
+//     &:before {
+//       border: 2px solid $gray-500;
+//     }
+//   }
+// }
 
 .form-check-label {
   padding-left: 2.5rem;


### PR DESCRIPTION
## スプリントバックログ

<blockquote class="trello-card"><a href="https://trello.com/c/Wu66OQMI/516-css%E3%81%AE%E5%B4%A9%E3%82%8C%E3%82%92%E8%A7%A3%E6%B6%88%E3%81%99%E3%82%8B">CSSの崩れを解消する</a></blockquote>
## やったこと
- CSSの記述部分のコメントアウト


<img width="447" alt="2017-12-06 18 23 11" src="https://user-images.githubusercontent.com/22652706/33654168-9cc91b76-dab2-11e7-9f5b-7113e66cc939.png">

## 備考
- cssのズレの解消方法がよくわからなかったので，該当部分を全てコメントアウトした．
- htmlでのcheckboxの表現ならば，bootstrapを適応させられるようだが，railsの書き方にbootstrapのテーマを適切に当てる方法がよくわからなかった．

