### PR TITLE
[作業中]emailを聞かなくする．screen_nameを聞く．

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,14 +1,15 @@
+# coding: utf-8
 class SessionsController < ApplicationController
   def new
   end
 
   def create
-    user = User.find_by(email: params[:session][:email])
+    user = User.find_by(name: params[:session][:name])
     if user && user.authenticate(params[:session][:password])
       log_in user
       redirect_to user
     else
-      flash.now[:danger] = 'Invalid email/password combination'
+      flash.now[:danger] = '利用できない組み合わせです．'
       render 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,10 +1,9 @@
-# coding: utf-8
 class SessionsController < ApplicationController
   def new
   end
 
   def create
-    user = User.find_by(name: params[:session][:name])
+    user = User.find_by(screen_name: params[:session][:screen_name])
     if user && user.authenticate(params[:session][:password])
       log_in user
       redirect_to user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
   private
 
    def user_params
-     params.require(:user).permit(:name,:password,
+     params.require(:user).permit(:name,:screen_name,:password,
                               :password_confirmation)
    end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
   private
 
    def user_params
-     params.require(:user).permit(:name, :email,:password,
+     params.require(:user).permit(:name,:password,
                               :password_confirmation)
    end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,5 @@ class User < ApplicationRecord
     has_one :item
     validates :name,  presence: true, length: { maximum: 50 }
     VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-    validates :email, presence: true, length: { maximum: 255 },
-                      format: { with: VALID_EMAIL_REGEX },
-                      uniqueness: { case_sensitive: false }
     has_secure_password
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@ class User < ApplicationRecord
     has_one :profile
     has_one :item
     validates :name,  presence: true, length: { maximum: 50 }
-    VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+    VALID_SCREEN_NAME_REGEX = /\A[a-zA-Z]+\z/i
+    validates :screen_name, presence: true, length: { maximum: 15 },
+                      format: { with: VALID_SCREEN_NAME_REGEX },
+                      uniqueness: { case_sensitive: false }
+
     has_secure_password
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,9 +5,6 @@
         <div class="col-md-6 col-md-offset-3">
             <%= form_for(:session, url: login_path) do |f| %>
 
-                <%= f.label :email %>
-                <%= f.email_field :email, class: 'form-control' %>
-
                 <%= f.label :password %>
                 <%= f.password_field :password, class: 'form-control' %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,6 +5,9 @@
         <div class="col-md-6 col-md-offset-3">
             <%= form_for(:session, url: login_path) do |f| %>
 
+                <%= f.label :screen_name %>
+                <%= f.email_field :screen_name, class: 'form-control' %>
+
                 <%= f.label :password %>
                 <%= f.password_field :password, class: 'form-control' %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -11,9 +11,6 @@
       <%= f.label :name ,"名前を設定してください"%>
       <%= f.text_field :name, class: 'form-control' %>
 
-      <%= f.label :email%>
-      <%= f.email_field :email, class: 'form-control' %>
-
       <%= f.label :password,"パスワードを設定してください"%> 
       <%= f.password_field :password, class: 'form-control' %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,2 @@
    <%# <%= @user.name %>
-   <%# <%= @user.email %>
 <%= link_to "プロフィールを登録してください!", new_profile_path, class: "btn btn-lg btn-primary" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,3 @@
-   <%# <%= @user.name %>
+    <%# <%= @user.name %>
+    <%# <%= @user.screen_name %>
 <%= link_to "プロフィールを登録してください!", new_profile_path, class: "btn btn-lg btn-primary" %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171123081305) do
+ActiveRecord::Schema.define(version: 20171207081334) do
 
   create_table "community_counters", force: :cascade do |t|
     t.integer "counter", default: 0
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 20171123081305) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171207081334) do
+ActiveRecord::Schema.define(version: 20171211030959) do
 
   create_table "community_counters", force: :cascade do |t|
     t.integer "counter", default: 0
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 20171207081334) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "notifytoken"
+    t.string "screen_name"
+    t.index ["screen_name"], name: "index_users_on_screen_name"
   end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,4 +3,5 @@
 Jhon:
   name: Smizh
 #  email: example@ezweb.ne.jp
+  screen_name: 'JhonJhon'
   password_digest: 'Rxn302n1'

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,5 +2,5 @@
 
 Jhon:
   name: Smizh
-  email: example@ezweb.ne.jp
+#  email: example@ezweb.ne.jp
   password_digest: 'Rxn302n1'

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,7 +5,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   test "login with invalid information" do
     get login_path
     assert_template 'sessions/new'
-    post login_path, params: { session: {password: "" } }
+    post login_path, params: { session: { screen_name: "",password: "" } }
     assert_template 'sessions/new'
     assert_not flash.empty?
     get root_path

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,7 +5,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   test "login with invalid information" do
     get login_path
     assert_template 'sessions/new'
-    post login_path, params: { session: { email: "", password: "" } }
+    post login_path, params: { session: {password: "" } }
     assert_template 'sessions/new'
     assert_not flash.empty?
     get root_path

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
 
   def setup 
-    @user = User.new(name: "Example User", email: "user@example.com",
+    @user = User.new(name: "Example User",
     password: "foobar", password_confirmation: "foobar")
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
 
   def setup 
-    @user = User.new(name: "Example User",
+    @user = User.new(name: "Example User",screen_name: "Exscreenname"
     password: "foobar", password_confirmation: "foobar")
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
 
   def setup 
-    @user = User.new(name: "Example User",screen_name: "Exscreenname"
+    @user = User.new(name: "Example User",screen_name: "Exscreenname",
     password: "foobar", password_confirmation: "foobar")
   end
 


### PR DESCRIPTION
## スプリントバックログ

<blockquote class="trello-card"><a href="https://trello.com/c/FEaBZ8hW/512-2-email%E5%85%A5%E5%8A%9B%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E3%81%AA%E3%81%8F%E3%81%99">2. email入力フォームをなくす</a></blockquote>

## やったこと
- emailカラムをusersテーブルから削除
```
rails g migration RemoveEmailFromUsers email                        
```
- emailを使っている部分を削除
## 備考
- ユーザーの特定をどうするか
find grep でemailを使っている部分を探して削除しただけなので，どのような問題が起きるかわかっていない．ユーザーは名前だけで特定することになるが，同じ名前を登録できないようにはまだしていない．
- (追記)ユーザーの特定をどうするか
emailの代わりに，screenname(twitterの@以下のユーザーIDのこと)を追加する．
- emailとscreennameを共存する形にするので，このブランチは放棄する．
