### PR TITLE
id名でログイン(登録)可能にした

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
       log_in user
       redirect_to user
     else
-      flash.now[:danger] = 'メールアドレス,レシコミIDのいずれかか, パスワードが間違っています'
+      flash.now[:danger] = 'メールアドレス,レシコミIDのいずれかが, パスワードが間違っています'
       render 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,12 +3,19 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email])
+    login_key = params[:session][:login_key]
+     user = ""
+     if login_key =~ /@/
+       user = User.find_by(email: params[:session][:login_key])
+     else
+       user = User.find_by(screen_name: params[:session][:login_key])
+     end
+
     if user && user.authenticate(params[:session][:password])
       log_in user
       redirect_to user
     else
-      flash.now[:danger] = 'メールアドレスか, パスワードが間違っています'
+      flash.now[:danger] = 'メールアドレス,レシコミIDのいずれかか, パスワードが間違っています'
       render 'new'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
 
    def user_params
      params.require(:user).permit(:name, :email,:password,
-                              :password_confirmation)
+                              :password_confirmation,:screen_name)
    end
 
    def correct_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,13 @@ class User < ApplicationRecord
     has_many :item
     validates :name,  presence: true, length: { maximum: 50 }
     VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+    VALID_NAME_REGEX = /\A\w+\z/i
     validates :email, presence: true, length: { maximum: 255 },
                       format: { with: VALID_EMAIL_REGEX },
                       uniqueness: { case_sensitive: false }
+    validates  :screen_name, presence: true, length: { maximum: 15},
+                     format: { with: VALID_NAME_REGEX},
+                      uniqueness: { case_sensitive: false }
+
     has_secure_password
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,9 @@ class User < ApplicationRecord
     VALID_NAME_REGEX = /\A\w+\z/i
     validates :email, presence: true, length: { maximum: 255 },
                       format: { with: VALID_EMAIL_REGEX },
-                      uniqueness: { case_sensitive: false }
+                      uniqueness: { case_sensitive: false }, if: -> { screen_name.blank?}
     validates  :screen_name, presence: true, length: { maximum: 15},
                      format: { with: VALID_NAME_REGEX},
-                      uniqueness: { case_sensitive: false }
-
+                      uniqueness: { case_sensitive: false }, if: -> { email.blank?}
     has_secure_password
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,8 +5,8 @@
         <div class="col-md-6 col-md-offset-3">
             <%= form_for(:session, url: login_path) do |f| %>
 
-                <%= f.label :email %>
-                <%= f.email_field :email, class: 'form-control' %>
+                <%= f.label :login_key %>
+                <%= f.email_field :login_key, class: 'form-control' %>
 
                 <%= f.label :password %>
                 <%= f.password_field :password, class: 'form-control' %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,7 +6,7 @@
             <%= form_for(:session, url: login_path) do |f| %>
 
                 <%= f.label :login_key %>
-                <%= f.email_field :login_key, class: 'form-control' %>
+                <%= f.text_field :login_key, disbale:"ime-mode", class: 'form-control' %>
 
                 <%= f.label :password %>
                 <%= f.password_field :password, class: 'form-control' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -11,10 +11,10 @@
       <%= f.label :name ,"名前を設定してください"%>
       <%= f.text_field :name, class: 'form-control' %>
 
-      <%= f.label :email%>
-      <%= f.email_field :email, class: 'form-control' %>
+      <%= f.label :screen_name, "レシコミIDを設定してください(半角英数字)"%>
+      <%= f.email_field :screen_name, class: 'form-control' %>
 
-      <%= f.label :password,"パスワードを設定してください"%> 
+      <%= f.label :password,"パスワードを設定してください"%>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :password_confirmation, "パスワードをもう一度入力してください" %>
@@ -25,5 +25,3 @@
     <% end %>
   </div>
 </div>
-
-

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,7 +12,7 @@
       <%= f.text_field :name, class: 'form-control' %>
 
       <%= f.label :screen_name, "レシコミIDを設定してください(半角英数字)"%>
-      <%= f.email_field :screen_name, class: 'form-control' %>
+      <%= f.text_field :screen_name, disbale: 'ime-mode', class: 'form-control' %>
 
       <%= f.label :password,"パスワードを設定してください"%>
       <%= f.password_field :password, class: 'form-control' %>

--- a/db/migrate/20171211043236_add_screen_name_to_users.rb
+++ b/db/migrate/20171211043236_add_screen_name_to_users.rb
@@ -2,5 +2,6 @@ class AddScreenNameToUsers < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :screen_name, :string
     add_index :users, :screen_name, unique: true
+    
   end
 end

--- a/db/migrate/20171211043236_add_screen_name_to_users.rb
+++ b/db/migrate/20171211043236_add_screen_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddScreenNameToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :screen_name, :string
+    add_index :users, :screen_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171123081305) do
+ActiveRecord::Schema.define(version: 20171211043236) do
 
   create_table "community_counters", force: :cascade do |t|
     t.integer "counter", default: 0
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 20171123081305) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "notifytoken"
+    t.string "screen_name"
+    t.index ["screen_name"], name: "index_users_on_screen_name", unique: true
   end
 
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,7 +5,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   test "login with invalid information" do
     get login_path
     assert_template 'sessions/new'
-    post login_path, params: { session: { email: "", password: "" } }
+    post login_path, params: { session: { login_key: "", password: "" } }
     assert_template 'sessions/new'
     assert_not flash.empty?
     get root_path


### PR DESCRIPTION
## スプリントバックログ

[2. 新規登録に必要ないemail情報を入力しなくて済むことで必要以上に自分の情報を入力しなくてすむ:8](https://trello.com/c/P1bSJgmM/506-2-%E6%96%B0%E8%A6%8F%E7%99%BB%E9%8C%B2%E3%81%AB%E5%BF%85%E8%A6%81%E3%81%AA%E3%81%84email%E6%83%85%E5%A0%B1%E3%82%92%E5%85%A5%E5%8A%9B%E3%81%97%E3%81%AA%E3%81%8F%E3%81%A6%E6%B8%88%E3%82%80%E3%81%93%E3%81%A8%E3%81%A7%E5%BF%85%E8%A6%81%E4%BB%A5%E4%B8%8A%E3%81%AB%E8%87%AA%E5%88%86%E3%81%AE%E6%83%85%E5%A0%B1%E3%82%92%E5%85%A5%E5%8A%9B%E3%81%97%E3%81%AA%E3%81%8F%E3%81%A6%E3%81%99%E3%82%808)

## やったこと
- 登録時にメールアドレスorレシコミID(Twitterの@以下のアレ)で登録出来るようにした
- それでログインも可能

## TODO
- 登録済みユーザーのアカウント追加機能フォーム
- アカウント名編集フォームの作成

## 備考

